### PR TITLE
use appropriate lengths for hash commitments

### DIFF
--- a/c-impl/PQCrypto-SIDH/src/poik.h
+++ b/c-impl/PQCrypto-SIDH/src/poik.h
@@ -20,24 +20,29 @@
     #define POIK_REPS       219
     #define POIK_WIDTH      4
     #define POIK_HEIGHT     7
+    #define HASH_BYTES      32      // length of hash commitments
+    #define HIDE_BYTES      64      // entropy in hash commitments
 #elif POIK_BITS == 503
     #define POIK_REPS       219
     #define POIK_WIDTH      4
     #define POIK_HEIGHT     7
+    #define HASH_BYTES      32      // length of hash commitments
+    #define HIDE_BYTES      64      // entropy in hash commitments
 #elif POIK_BITS == 610
-    #define POIK_REPS       327
+    #define POIK_REPS       329
     #define POIK_WIDTH      4
     #define POIK_HEIGHT     7
+    #define HASH_BYTES      48      // length of hash commitments
+    #define HIDE_BYTES      96      // entropy in hash commitments
 #elif POIK_BITS == 751
     #define POIK_REPS       438
     #define POIK_WIDTH      4
     #define POIK_HEIGHT     7
+    #define HASH_BYTES      64      // length of hash commitments
+    #define HIDE_BYTES      128     // entropy in hash commitments
 #else
 #error "please #define POIK_BITS to {434,503,610,751} prior to including <poik.h>"
 #endif
-
-#define HASH_BYTES      32      // length of hash commitments
-#define HIDE_BYTES      55      // entropy in hash commitments  //TODO
 
 ////////////////////////////////////////////////////////////////
 

--- a/sage-impl/verify.sage
+++ b/sage-impl/verify.sage
@@ -199,7 +199,7 @@ class Proof(NamedTuple):
 params = {
         'p434': Parameters(216, 137, 219, 4, 7),
         'p503': Parameters(250, 159, 219, 4, 7),
-        'p610': Parameters(305, 192, 327, 4, 7),
+        'p610': Parameters(305, 192, 329, 4, 7),
         'p751': Parameters(372, 239, 438, 4, 7),
     }
 


### PR DESCRIPTION
We seem to require $2\lambda$ bits of hash output and $\approx4\lambda$ bits of entropy.

Also, fix a typo in the number of proof repetitions for one of the parameter sets while we're at it.